### PR TITLE
Feature/remove complexity and pagination constraints

### DIFF
--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elrondnetwork/erdnest",
-  "version": "0.2.18",
+  "version": "0.2.19",
   "description": "NestJS microservice template",
   "main": "lib/src/index.js",
   "types": "lib/src/index.d.ts",

--- a/packages/common/src/interceptors/complexity.interceptor.ts
+++ b/packages/common/src/interceptors/complexity.interceptor.ts
@@ -7,7 +7,7 @@ import { ComplexityUtils } from "../common/complexity/complexity.utils";
 
 @Injectable()
 export class ComplexityInterceptor implements NestInterceptor {
-  complexityThreshold: number = 10000;
+  constructor(private readonly complexityThreshold: number = 10000) { }
 
   intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
     const contextType: string = context.getType();

--- a/packages/common/src/interceptors/complexity.interceptor.ts
+++ b/packages/common/src/interceptors/complexity.interceptor.ts
@@ -7,7 +7,7 @@ import { ComplexityUtils } from "../common/complexity/complexity.utils";
 
 @Injectable()
 export class ComplexityInterceptor implements NestInterceptor {
-  private readonly complexityThreshold: number = 10000;
+  private readonly complexityThreshold: number = 100000;
 
   intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
     const contextType: string = context.getType();

--- a/packages/common/src/interceptors/complexity.interceptor.ts
+++ b/packages/common/src/interceptors/complexity.interceptor.ts
@@ -7,7 +7,7 @@ import { ComplexityUtils } from "../common/complexity/complexity.utils";
 
 @Injectable()
 export class ComplexityInterceptor implements NestInterceptor {
-  private readonly complexityThreshold: number = 100000;
+  complexityThreshold: number = 10000;
 
   intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
     const contextType: string = context.getType();

--- a/packages/common/src/interceptors/pagination.interceptor.ts
+++ b/packages/common/src/interceptors/pagination.interceptor.ts
@@ -2,7 +2,7 @@ import { CallHandler, ExecutionContext, HttpException, HttpStatus, NestIntercept
 import { Observable } from "rxjs";
 
 export class PaginationInterceptor implements NestInterceptor {
-  constructor(readonly maxSize: number = 10000) { }
+  constructor(private readonly maxSize: number = 10000) { }
 
   intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
     const contextType: string = context.getType();

--- a/packages/common/src/interceptors/pagination.interceptor.ts
+++ b/packages/common/src/interceptors/pagination.interceptor.ts
@@ -2,7 +2,7 @@ import { CallHandler, ExecutionContext, HttpException, HttpStatus, NestIntercept
 import { Observable } from "rxjs";
 
 export class PaginationInterceptor implements NestInterceptor {
-  constructor(private readonly maxSize: number = 10000) { }
+  constructor(private readonly maxSize: number = 100000) { }
 
   intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
     const contextType: string = context.getType();

--- a/packages/common/src/interceptors/pagination.interceptor.ts
+++ b/packages/common/src/interceptors/pagination.interceptor.ts
@@ -2,7 +2,7 @@ import { CallHandler, ExecutionContext, HttpException, HttpStatus, NestIntercept
 import { Observable } from "rxjs";
 
 export class PaginationInterceptor implements NestInterceptor {
-  constructor(private readonly maxSize: number = 100000) { }
+  constructor(readonly maxSize: number = 10000) { }
 
   intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
     const contextType: string = context.getType();


### PR DESCRIPTION
Removing private constraints for pagination and complexity will allow us to serve more than 10000 results through Elrond API self hosted instance. Since `complexityThreshold` is currently private, we cannot override it.