### PR TITLE
JWT or native auth guard fix

### DIFF
--- a/packages/common/package-lock.json
+++ b/packages/common/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "@multiversx/sdk-nestjs",
-  "version": "0.3.14",
+  "version": "0.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@multiversx/sdk-nestjs",
-      "version": "0.3.14",
+      "version": "0.4.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@golevelup/nestjs-rabbitmq": "^3.0.0",
         "@multiversx/sdk-native-auth-client": "^1.0.0",
-        "@multiversx/sdk-native-auth-server": "^1.0.0",
+        "@multiversx/sdk-native-auth-server": "^1.0.1",
         "@types/redis": "^2.8.32",
         "agentkeepalive": "^4.2.1",
         "axios": "^0.27.2",
@@ -2638,9 +2638,9 @@
       }
     },
     "node_modules/@multiversx/sdk-native-auth-server": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@multiversx/sdk-native-auth-server/-/sdk-native-auth-server-1.0.0.tgz",
-      "integrity": "sha512-QDVEN2hjxU0O+H7KLNzBqvRYSomGhRwY0bEJrmEEUWJlALHiKJOeVQTeyBzRRnRzJlrYMHiaCzqO8uwg6Gy4SQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@multiversx/sdk-native-auth-server/-/sdk-native-auth-server-1.0.1.tgz",
+      "integrity": "sha512-V0BylwrPwK4GArUfJ4vXN6Un5IF5EVvbieBIzGjfAfaAc+UUvYfqLBcuEJ0V206Tc9T0gkLQQiNGqjXEltdfRg==",
       "dependencies": {
         "@multiversx/sdk-core": "^11.2.0",
         "@multiversx/sdk-wallet": "^2.1.1",
@@ -11775,9 +11775,9 @@
       }
     },
     "@multiversx/sdk-native-auth-server": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@multiversx/sdk-native-auth-server/-/sdk-native-auth-server-1.0.0.tgz",
-      "integrity": "sha512-QDVEN2hjxU0O+H7KLNzBqvRYSomGhRwY0bEJrmEEUWJlALHiKJOeVQTeyBzRRnRzJlrYMHiaCzqO8uwg6Gy4SQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@multiversx/sdk-native-auth-server/-/sdk-native-auth-server-1.0.1.tgz",
+      "integrity": "sha512-V0BylwrPwK4GArUfJ4vXN6Un5IF5EVvbieBIzGjfAfaAc+UUvYfqLBcuEJ0V206Tc9T0gkLQQiNGqjXEltdfRg==",
       "requires": {
         "@multiversx/sdk-core": "^11.2.0",
         "@multiversx/sdk-wallet": "^2.1.1",

--- a/packages/common/package-lock.json
+++ b/packages/common/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@golevelup/nestjs-rabbitmq": "^3.0.0",
         "@multiversx/sdk-native-auth-client": "^0.1.8",
-        "@multiversx/sdk-native-auth-server": "^0.2.3",
+        "@multiversx/sdk-native-auth-server": "^0.2.6",
         "@types/redis": "^2.8.32",
         "agentkeepalive": "^4.2.1",
         "axios": "^0.27.2",
@@ -2637,9 +2637,9 @@
       }
     },
     "node_modules/@multiversx/sdk-native-auth-server": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/@multiversx/sdk-native-auth-server/-/sdk-native-auth-server-0.2.5.tgz",
-      "integrity": "sha512-DnrCpSCJALtllnDlzGB4qzLXiv1JgySyMWoCMhiu8ZtnmU01uUFFbK+FqhM2HFijzKatPyE/Imy+4WFFNWei8A==",
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/@multiversx/sdk-native-auth-server/-/sdk-native-auth-server-0.2.6.tgz",
+      "integrity": "sha512-7n/GH1dxbxsQ1uC+EOWNMtA7e5BM8hLc8Iuf4zYyEkRwqerAx61GBQoABRxrOBfTDF3GikQFtFtBq+CP+8uwBg==",
       "dependencies": {
         "@multiversx/sdk-core": "^11.2.0",
         "@multiversx/sdk-wallet": "^2.1.1",
@@ -11774,9 +11774,9 @@
       }
     },
     "@multiversx/sdk-native-auth-server": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/@multiversx/sdk-native-auth-server/-/sdk-native-auth-server-0.2.5.tgz",
-      "integrity": "sha512-DnrCpSCJALtllnDlzGB4qzLXiv1JgySyMWoCMhiu8ZtnmU01uUFFbK+FqhM2HFijzKatPyE/Imy+4WFFNWei8A==",
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/@multiversx/sdk-native-auth-server/-/sdk-native-auth-server-0.2.6.tgz",
+      "integrity": "sha512-7n/GH1dxbxsQ1uC+EOWNMtA7e5BM8hLc8Iuf4zYyEkRwqerAx61GBQoABRxrOBfTDF3GikQFtFtBq+CP+8uwBg==",
       "requires": {
         "@multiversx/sdk-core": "^11.2.0",
         "@multiversx/sdk-wallet": "^2.1.1",

--- a/packages/common/package-lock.json
+++ b/packages/common/package-lock.json
@@ -10,8 +10,8 @@
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@golevelup/nestjs-rabbitmq": "^3.0.0",
-        "@multiversx/sdk-native-auth-client": "^0.1.8",
-        "@multiversx/sdk-native-auth-server": "^0.2.6",
+        "@multiversx/sdk-native-auth-client": "^1.0.0",
+        "@multiversx/sdk-native-auth-server": "^1.0.0",
         "@types/redis": "^2.8.32",
         "agentkeepalive": "^4.2.1",
         "axios": "^0.27.2",
@@ -2629,17 +2629,17 @@
       }
     },
     "node_modules/@multiversx/sdk-native-auth-client": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/@multiversx/sdk-native-auth-client/-/sdk-native-auth-client-0.1.8.tgz",
-      "integrity": "sha512-1+kJN8q2+gr3Ez17CfOAo3AIXbPinfoDdc0DbcRLboBm1G57x8QSpTTVZHuix4HOGnUL4QUncjInG6we8TugTQ==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@multiversx/sdk-native-auth-client/-/sdk-native-auth-client-1.0.0.tgz",
+      "integrity": "sha512-fRV358JCPYvc3XLoss/SuqGQkDVg3bgNEjuZ6V1yOKePsxbnr6aLEDIKvyL/Ayqh4GndTV1gpVxaVS+CALeWfg==",
       "dependencies": {
         "axios": "^0.27.2"
       }
     },
     "node_modules/@multiversx/sdk-native-auth-server": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/@multiversx/sdk-native-auth-server/-/sdk-native-auth-server-0.2.6.tgz",
-      "integrity": "sha512-7n/GH1dxbxsQ1uC+EOWNMtA7e5BM8hLc8Iuf4zYyEkRwqerAx61GBQoABRxrOBfTDF3GikQFtFtBq+CP+8uwBg==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@multiversx/sdk-native-auth-server/-/sdk-native-auth-server-1.0.0.tgz",
+      "integrity": "sha512-QDVEN2hjxU0O+H7KLNzBqvRYSomGhRwY0bEJrmEEUWJlALHiKJOeVQTeyBzRRnRzJlrYMHiaCzqO8uwg6Gy4SQ==",
       "dependencies": {
         "@multiversx/sdk-core": "^11.2.0",
         "@multiversx/sdk-wallet": "^2.1.1",
@@ -11766,17 +11766,17 @@
       }
     },
     "@multiversx/sdk-native-auth-client": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/@multiversx/sdk-native-auth-client/-/sdk-native-auth-client-0.1.8.tgz",
-      "integrity": "sha512-1+kJN8q2+gr3Ez17CfOAo3AIXbPinfoDdc0DbcRLboBm1G57x8QSpTTVZHuix4HOGnUL4QUncjInG6we8TugTQ==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@multiversx/sdk-native-auth-client/-/sdk-native-auth-client-1.0.0.tgz",
+      "integrity": "sha512-fRV358JCPYvc3XLoss/SuqGQkDVg3bgNEjuZ6V1yOKePsxbnr6aLEDIKvyL/Ayqh4GndTV1gpVxaVS+CALeWfg==",
       "requires": {
         "axios": "^0.27.2"
       }
     },
     "@multiversx/sdk-native-auth-server": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/@multiversx/sdk-native-auth-server/-/sdk-native-auth-server-0.2.6.tgz",
-      "integrity": "sha512-7n/GH1dxbxsQ1uC+EOWNMtA7e5BM8hLc8Iuf4zYyEkRwqerAx61GBQoABRxrOBfTDF3GikQFtFtBq+CP+8uwBg==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@multiversx/sdk-native-auth-server/-/sdk-native-auth-server-1.0.0.tgz",
+      "integrity": "sha512-QDVEN2hjxU0O+H7KLNzBqvRYSomGhRwY0bEJrmEEUWJlALHiKJOeVQTeyBzRRnRzJlrYMHiaCzqO8uwg6Gy4SQ==",
       "requires": {
         "@multiversx/sdk-core": "^11.2.0",
         "@multiversx/sdk-wallet": "^2.1.1",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-nestjs",
-  "version": "0.3.15",
+  "version": "0.4.0",
   "description": "NestJS microservice template",
   "main": "lib/src/index.js",
   "types": "lib/src/index.d.ts",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -49,8 +49,8 @@
     "typescript": "^4.3.5"
   },
   "dependencies": {
-    "@multiversx/sdk-native-auth-client": "^0.1.8",
-    "@multiversx/sdk-native-auth-server": "^0.2.6",
+    "@multiversx/sdk-native-auth-client": "^1.0.0",
+    "@multiversx/sdk-native-auth-server": "^1.0.0",
     "@golevelup/nestjs-rabbitmq": "^3.0.0",
     "@types/redis": "^2.8.32",
     "agentkeepalive": "^4.2.1",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-nestjs",
-  "version": "0.3.14",
+  "version": "0.3.15",
   "description": "NestJS microservice template",
   "main": "lib/src/index.js",
   "types": "lib/src/index.d.ts",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -50,7 +50,7 @@
   },
   "dependencies": {
     "@multiversx/sdk-native-auth-client": "^1.0.0",
-    "@multiversx/sdk-native-auth-server": "^1.0.0",
+    "@multiversx/sdk-native-auth-server": "^1.0.1",
     "@golevelup/nestjs-rabbitmq": "^3.0.0",
     "@types/redis": "^2.8.32",
     "agentkeepalive": "^4.2.1",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-nestjs",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "NestJS microservice template",
   "main": "lib/src/index.js",
   "types": "lib/src/index.d.ts",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -50,7 +50,7 @@
   },
   "dependencies": {
     "@multiversx/sdk-native-auth-client": "^0.1.8",
-    "@multiversx/sdk-native-auth-server": "^0.2.3",
+    "@multiversx/sdk-native-auth-server": "^0.2.6",
     "@golevelup/nestjs-rabbitmq": "^3.0.0",
     "@types/redis": "^2.8.32",
     "agentkeepalive": "^4.2.1",

--- a/packages/common/src/common/config/erdnest.config.service.ts
+++ b/packages/common/src/common/config/erdnest.config.service.ts
@@ -4,4 +4,8 @@ export interface ErdnestConfigService {
   getJwtSecret(): string;
 
   getApiUrl(): string;
+
+  getNativeAuthMaxExpirySeconds(): number;
+
+  getNativeAuthAcceptedOrigins(): string[];
 }

--- a/packages/common/src/guards/errors/native.auth.invalid.origin.error.ts
+++ b/packages/common/src/guards/errors/native.auth.invalid.origin.error.ts
@@ -1,0 +1,7 @@
+import { NativeAuthError } from "@multiversx/sdk-native-auth-server";
+
+export class NativeAuthInvalidOriginError extends NativeAuthError {
+  constructor(actualOrigin: string, expectedOrigin: string) {
+    super(`Invalid origin '${actualOrigin}'. should be '${expectedOrigin}'`);
+  }
+}

--- a/packages/common/src/guards/jwt.authenticate.guard.ts
+++ b/packages/common/src/guards/jwt.authenticate.guard.ts
@@ -1,13 +1,10 @@
 import { Injectable, CanActivate, ExecutionContext, Inject } from '@nestjs/common';
-import { TokenExpiredError, verify } from 'jsonwebtoken';
-import { OriginLogger } from '../utils/origin.logger';
+import { verify } from 'jsonwebtoken';
 import { ErdnestConfigService } from '../common/config/erdnest.config.service';
 import { ERDNEST_CONFIG_SERVICE } from '../utils/erdnest.constants';
 
 @Injectable()
 export class JwtAuthenticateGuard implements CanActivate {
-  private readonly logger = new OriginLogger(JwtAuthenticateGuard.name);
-
   constructor(
     @Inject(ERDNEST_CONFIG_SERVICE)
     private readonly erdnestConfigService: ErdnestConfigService
@@ -43,11 +40,6 @@ export class JwtAuthenticateGuard implements CanActivate {
       });
 
     } catch (error) {
-      if (error instanceof TokenExpiredError) {
-        return false;
-      }
-
-      this.logger.error(error);
       return false;
     }
 

--- a/packages/common/src/guards/jwt.authenticate.guard.ts
+++ b/packages/common/src/guards/jwt.authenticate.guard.ts
@@ -40,6 +40,13 @@ export class JwtAuthenticateGuard implements CanActivate {
       });
 
     } catch (error) {
+      // @ts-ignore
+      const message = error?.message;
+      if (message) {
+        request.res.set('X-Jwt-Auth-Error-Type', error.constructor.name);
+        request.res.set('X-Jwt-Auth-Error-Message', message);
+      }
+
       return false;
     }
 


### PR DESCRIPTION
Reasoning:
- JWT or native auth guard did not work correctly

What's changed:
- Use latest native auth functionality (v1)
- Integrate accepted origins, as well as max expiry seconds in config
- Instead of logging errors, return them in the response headers