### PR TITLE
Fix fields array parameter

### DIFF
--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-nestjs",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "NestJS microservice template",
   "main": "lib/src/index.js",
   "types": "lib/src/index.d.ts",

--- a/packages/common/src/interceptors/fields.interceptor.ts
+++ b/packages/common/src/interceptors/fields.interceptor.ts
@@ -20,7 +20,7 @@ export class FieldsInterceptor implements NestInterceptor {
         tap(async (result) => {
           const fieldsArgument = request.query.fields;
           if (fieldsArgument) {
-            const fields = fieldsArgument.split(',');
+            const fields = Array.isArray(fieldsArgument) ? fieldsArgument : fieldsArgument.split(',');
             if (Array.isArray(result)) {
               for (const item of result) {
                 this.transformItem(item, fields);


### PR DESCRIPTION
When performing queries of the form `/accounts?fields[]=address&fields[]=balance`, the `fields.interceptor` component was causing the whole microservice to crash
This situation is now handled so that it doesn't crash and also the correct values are taken