### PR TITLE
extra array extension functions

### DIFF
--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-nestjs",
-  "version": "0.4.19",
+  "version": "0.4.20",
   "description": "NestJS microservice template",
   "main": "lib/src/index.js",
   "types": "lib/src/index.d.ts",

--- a/packages/common/src/utils/extensions/array.extensions.ts
+++ b/packages/common/src/utils/extensions/array.extensions.ts
@@ -315,8 +315,24 @@ Array.prototype.shuffle = function <T>(): T[] {
   return array;
 };
 
+Array.prototype.includesSome = function <T>(elements: T[]): boolean {
+  return elements.some(el => this.includes(el));
+};
+
+Array.prototype.includesNone = function <T>(elements: T[]): boolean {
+  return !elements.some(el => this.includes(el));
+};
+
+Array.prototype.includesEvery = function <T>(elements: T[]): boolean {
+  return elements.every(el => this.includes(el));
+};
+
+Array.prototype.none = function <T>(predicate: (value: T, index: number, array: T[]) => unknown, thisArg?: any): boolean {
+  return !this.some(predicate, thisArg);
+};
+
 declare interface Array<T> {
-  groupBy(predicate: (item: T) => any, asArray? :boolean): any;
+  groupBy(predicate: (item: T) => any, asArray?: boolean): any;
   selectMany<TOUT>(predicate: (item: T) => TOUT[]): TOUT[];
   first(predicate?: (item: T) => boolean): T | undefined;
   mapIndexed<TOUT>(items: TOUT[], predicate: (item: TOUT) => T): (TOUT | undefined)[];
@@ -336,4 +352,8 @@ declare interface Array<T> {
   toRecordAsync<TOUT>(keyPredicate: (item: T) => string, valuePredicate: (item: T) => Promise<TOUT>): Promise<Record<string, TOUT>>;
   remove(element: T): void;
   shuffle(): T[];
+  none(predicate: (value: T, index: number, array: T[]) => unknown, thisArg?: any): boolean;
+  includesSome(elements: T[]): boolean;
+  includesNone(elements: T[]): boolean;
+  includesEvery(elements: T[]): boolean;
 }

--- a/packages/common/test/extensions/array.extensions.spec.ts
+++ b/packages/common/test/extensions/array.extensions.spec.ts
@@ -332,4 +332,41 @@ describe('Array Extensions', () => {
     array.remove('x');
     expect(array).toEqual(['a', 'c', 'd']);
   });
+
+  describe('None', () => {
+    const array = [1, 2, 3, 4, 5];
+    expect(array.none(x => x > 5)).toStrictEqual(true);
+    expect(array.none(x => x <= 1)).toStrictEqual(false);
+    expect(array.none(x => x <= 5)).toStrictEqual(false);
+  });
+
+  describe('includesSome', () => {
+    const array = [1, 2, 3, 4, 5];
+    expect(array.includesSome([1])).toStrictEqual(true);
+    expect(array.includesSome([1, 6])).toStrictEqual(true);
+    expect(array.includesSome([1, 2, 3])).toStrictEqual(true);
+    expect(array.includesSome([1, 2, 3, 4, 5])).toStrictEqual(true);
+    expect(array.includesSome([6])).toStrictEqual(false);
+    expect(array.includesSome([6, 7, 8])).toStrictEqual(false);
+  });
+
+  describe('includesEvery', () => {
+    const array = [1, 2, 3, 4, 5];
+    expect(array.includesEvery([1])).toStrictEqual(true);
+    expect(array.includesEvery([1, 6])).toStrictEqual(false);
+    expect(array.includesEvery([1, 2, 3])).toStrictEqual(true);
+    expect(array.includesEvery([1, 2, 3, 4, 5])).toStrictEqual(true);
+    expect(array.includesEvery([6])).toStrictEqual(false);
+    expect(array.includesEvery([6, 7, 8])).toStrictEqual(false);
+  });
+
+  describe('includesNone', () => {
+    const array = [1, 2, 3, 4, 5];
+    expect(array.includesNone([1])).toStrictEqual(false);
+    expect(array.includesNone([1, 6])).toStrictEqual(false);
+    expect(array.includesNone([1, 2, 3])).toStrictEqual(false);
+    expect(array.includesNone([1, 2, 3, 4, 5])).toStrictEqual(false);
+    expect(array.includesNone([6])).toStrictEqual(true);
+    expect(array.includesNone([6, 7, 8])).toStrictEqual(true);
+  });
 });


### PR DESCRIPTION
What's changed:
- added `none`, `includesSome`, `includesNone`, `includesEvery` extension functions for arrays

How to test:
- see unit tests in this PR