### PR TITLE
In memory cache service shared across modules

### DIFF
--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-nestjs",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "NestJS microservice template",
   "main": "lib/src/index.js",
   "types": "lib/src/index.d.ts",


### PR DESCRIPTION
In memory cache is not shared across applications, meaning that if application A sets a value in cache, application B still has the old value
This happens where for example an application is responsible for handling pubsub events, while another application is responsible for serving api calls