### PR TITLE
Use referer when no origin provided

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,7 +1,7 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
   "useWorkspaces": true,
-  "version": "1.2.3",
+  "version": "1.2.4",
   "packages": [
     "packages/*"
   ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -8215,7 +8215,7 @@
       }
     },
     "node_modules/jest-pnp-resolver": {
-      "version": "1.2.3",
+      "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
       "integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==",
       "dev": true,
@@ -11875,7 +11875,7 @@
       "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
     },
     "node_modules/queue-microtask": {
-      "version": "1.2.3",
+      "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
       "dev": true,
@@ -13902,7 +13902,7 @@
       }
     },
     "node_modules/word-wrap": {
-      "version": "1.2.3",
+      "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
       "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
       "dev": true,
@@ -14117,7 +14117,7 @@
     },
     "packages/auth": {
       "name": "@multiversx/sdk-nestjs-auth",
-      "version": "1.2.3",
+      "version": "1.2.4",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@multiversx/sdk-core": "*",
@@ -14251,7 +14251,7 @@
     },
     "packages/cache": {
       "name": "@multiversx/sdk-nestjs-cache",
-      "version": "1.2.3",
+      "version": "1.2.4",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "lru-cache": "^8.0.4",
@@ -14309,7 +14309,7 @@
     },
     "packages/common": {
       "name": "@multiversx/sdk-nestjs-common",
-      "version": "1.2.3",
+      "version": "1.2.4",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@multiversx/sdk-core": "^11.4.1",
@@ -14342,7 +14342,7 @@
     },
     "packages/elastic": {
       "name": "@multiversx/sdk-nestjs-elastic",
-      "version": "1.2.3",
+      "version": "1.2.4",
       "license": "GPL-3.0-or-later",
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^5.12.0",
@@ -14357,7 +14357,7 @@
     },
     "packages/http": {
       "name": "@multiversx/sdk-nestjs-http",
-      "version": "1.2.3",
+      "version": "1.2.4",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@multiversx/sdk-wallet": "3.0.0",
@@ -14424,7 +14424,7 @@
     },
     "packages/monitoring": {
       "name": "@multiversx/sdk-nestjs-monitoring",
-      "version": "1.2.3",
+      "version": "1.2.4",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "prom-client": "^14.0.1",
@@ -14443,7 +14443,7 @@
     },
     "packages/rabbitmq": {
       "name": "@multiversx/sdk-nestjs-rabbitmq",
-      "version": "1.2.3",
+      "version": "1.2.4",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@golevelup/nestjs-rabbitmq": "^3.0.0",
@@ -14464,7 +14464,7 @@
     },
     "packages/redis": {
       "name": "@multiversx/sdk-nestjs-redis",
-      "version": "1.2.3",
+      "version": "1.2.4",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "ioredis": "^5.2.3"
@@ -20970,7 +20970,7 @@
       }
     },
     "jest-pnp-resolver": {
-      "version": "1.2.3",
+      "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
       "integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==",
       "dev": true,
@@ -23818,7 +23818,7 @@
       "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
     },
     "queue-microtask": {
-      "version": "1.2.3",
+      "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
       "dev": true
@@ -25343,7 +25343,7 @@
       }
     },
     "word-wrap": {
-      "version": "1.2.3",
+      "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
       "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
       "dev": true

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-nestjs-auth",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "Multiversx SDK Nestjs auth package",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/auth/test/native.auth.guard.spec.ts
+++ b/packages/auth/test/native.auth.guard.spec.ts
@@ -1,0 +1,14 @@
+import { NativeAuthGuard } from "../src/native.auth.guard";
+
+describe('getOrigin', () => {
+  it('origin tests', () => {
+    expect(NativeAuthGuard.getOrigin({ origin: 'https://localhost:3001' })).toStrictEqual('https://localhost:3001');
+    expect(NativeAuthGuard.getOrigin({ origin: 'https://api.multiversx.com' })).toStrictEqual('https://api.multiversx.com');
+    expect(NativeAuthGuard.getOrigin({ origin: 'http://localhost' })).toStrictEqual('http://localhost');
+  });
+
+  it('referer tests', () => {
+    expect(NativeAuthGuard.getOrigin({ referer: 'https://localhost:3001/' })).toStrictEqual('https://localhost:3001');
+    expect(NativeAuthGuard.getOrigin({ referer: 'http://localhost:3001/helloworld' })).toStrictEqual('http://localhost:3001');
+  });
+});

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-nestjs-cache",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "Multiversx SDK Nestjs cache package",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-nestjs-common",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "Multiversx SDK Nestjs common package",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/elastic/package.json
+++ b/packages/elastic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-nestjs-elastic",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "Multiversx SDK Nestjs elastic package",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-nestjs-http",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "Multiversx SDK Nestjs http package",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/monitoring/package.json
+++ b/packages/monitoring/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-nestjs-monitoring",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "Multiversx SDK Nestjs monitoring package",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/rabbitmq/package.json
+++ b/packages/rabbitmq/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-nestjs-rabbitmq",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "Multiversx SDK Nestjs rabbitmq client package",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/redis/package.json
+++ b/packages/redis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-nestjs-redis",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "Multiversx SDK Nestjs redis client package",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",


### PR DESCRIPTION
When loading the swaggerdoc interface for an API, the url of it is the same as the url of the underlying API

This prompts the browser to not send the `Origin` header, only the `Referer` header

In order to support native auth also from the swaggerdoc interface, we need to take the `Referer` header into account as well