### PR TITLE
Elasticsearch Range query string value always

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,7 +1,7 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
   "useWorkspaces": true,
-  "version": "3.1.4",
+  "version": "3.1.5",
   "packages": [
     "packages/*"
   ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -15232,7 +15232,7 @@
     },
     "packages/auth": {
       "name": "@multiversx/sdk-nestjs-auth",
-      "version": "3.1.4",
+      "version": "3.1.5",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@multiversx/sdk-core": "^12.15.0",
@@ -15256,7 +15256,7 @@
     },
     "packages/cache": {
       "name": "@multiversx/sdk-nestjs-cache",
-      "version": "3.1.4",
+      "version": "3.1.5",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "lru-cache": "^8.0.4",
@@ -15296,7 +15296,7 @@
     },
     "packages/common": {
       "name": "@multiversx/sdk-nestjs-common",
-      "version": "3.1.4",
+      "version": "3.1.5",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@multiversx/sdk-core": "^12.15.0",
@@ -15328,7 +15328,7 @@
     },
     "packages/elastic": {
       "name": "@multiversx/sdk-nestjs-elastic",
-      "version": "3.1.4",
+      "version": "3.1.5",
       "license": "GPL-3.0-or-later",
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^5.12.0",
@@ -15343,7 +15343,7 @@
     },
     "packages/http": {
       "name": "@multiversx/sdk-nestjs-http",
-      "version": "3.1.4",
+      "version": "3.1.5",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@multiversx/sdk-native-auth-client": "^1.0.7",
@@ -15367,7 +15367,7 @@
     },
     "packages/monitoring": {
       "name": "@multiversx/sdk-nestjs-monitoring",
-      "version": "3.1.4",
+      "version": "3.1.5",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "prom-client": "^14.0.1",
@@ -15386,7 +15386,7 @@
     },
     "packages/rabbitmq": {
       "name": "@multiversx/sdk-nestjs-rabbitmq",
-      "version": "3.1.4",
+      "version": "3.1.5",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@golevelup/nestjs-rabbitmq": "4.0.0",
@@ -15407,7 +15407,7 @@
     },
     "packages/redis": {
       "name": "@multiversx/sdk-nestjs-redis",
-      "version": "3.1.4",
+      "version": "3.1.5",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "ioredis": "^5.2.3"

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-nestjs-auth",
-  "version": "3.1.4",
+  "version": "3.1.5",
   "description": "Multiversx SDK Nestjs auth package",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-nestjs-cache",
-  "version": "3.1.4",
+  "version": "3.1.5",
   "description": "Multiversx SDK Nestjs cache package",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-nestjs-common",
-  "version": "3.1.4",
+  "version": "3.1.5",
   "description": "Multiversx SDK Nestjs common package",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/elastic/package.json
+++ b/packages/elastic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-nestjs-elastic",
-  "version": "3.1.4",
+  "version": "3.1.5",
   "description": "Multiversx SDK Nestjs elastic package",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/elastic/src/entities/range.query.ts
+++ b/packages/elastic/src/entities/range.query.ts
@@ -10,10 +10,10 @@ export class RangeQuery extends AbstractQuery {
   }
 
   getQuery(): any {
-    const conditions: Record<string, number> = {};
+    const conditions: Record<string, string> = {};
 
     for (const range of this.ranges) {
-      conditions[range.key] = range.value;
+      conditions[range.key] = range.value.toString();
     }
 
     return { range: { [this.key]: conditions } };

--- a/packages/elastic/test/elastic.utils.spec.ts
+++ b/packages/elastic/test/elastic.utils.spec.ts
@@ -82,12 +82,12 @@ describe('Elastic Query', () => {
 
     elasticQuery1.withRangeFilter('test', new RangeLowerThanOrEqual(100));
     expect(elasticQuery1.filter.length).toEqual(1);
-    expect(elasticQuery1.filter[0].getQuery()).toMatchObject({ range: { test: { lte: 100 } } });
+    expect(elasticQuery1.filter[0].getQuery()).toMatchObject({ range: { test: { lte: '100' } } });
 
     const elasticQuery2 = ElasticQuery.create();
     elasticQuery2.withRangeFilter('test', new RangeGreaterThanOrEqual(1), new RangeLowerThanOrEqual(100));
     expect(elasticQuery2.filter.length).toEqual(1);
-    expect(elasticQuery2.filter[0].getQuery()).toMatchObject({ range: { test: { lte: 100, gte: 1 } } });
+    expect(elasticQuery2.filter[0].getQuery()).toMatchObject({ range: { test: { lte: '100', gte: '1' } } });
 
     expect(elasticQuery2.toJson().query.bool.filter).toBeDefined();
   });

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-nestjs-http",
-  "version": "3.1.4",
+  "version": "3.1.5",
   "description": "Multiversx SDK Nestjs http package",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/monitoring/package.json
+++ b/packages/monitoring/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-nestjs-monitoring",
-  "version": "3.1.4",
+  "version": "3.1.5",
   "description": "Multiversx SDK Nestjs monitoring package",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/rabbitmq/package.json
+++ b/packages/rabbitmq/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-nestjs-rabbitmq",
-  "version": "3.1.4",
+  "version": "3.1.5",
   "description": "Multiversx SDK Nestjs rabbitmq client package",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/redis/package.json
+++ b/packages/redis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-nestjs-redis",
-  "version": "3.1.4",
+  "version": "3.1.5",
   "description": "Multiversx SDK Nestjs redis client package",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",


### PR DESCRIPTION
In order to maintain compatibility with ES 8, when specifying range queries, define value as string