### PR TITLE
Track request id in origin logger

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,7 +1,7 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
   "useWorkspaces": true,
-  "version": "3.2.1",
+  "version": "3.2.2",
   "packages": [
     "packages/*"
   ],

--- a/lerna.json
+++ b/lerna.json
@@ -1,7 +1,7 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
   "useWorkspaces": true,
-  "version": "3.2.3",
+  "version": "3.2.4",
   "packages": [
     "packages/*"
   ],

--- a/lerna.json
+++ b/lerna.json
@@ -1,7 +1,7 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
   "useWorkspaces": true,
-  "version": "3.2.0",
+  "version": "3.2.1",
   "packages": [
     "packages/*"
   ],

--- a/lerna.json
+++ b/lerna.json
@@ -1,7 +1,7 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
   "useWorkspaces": true,
-  "version": "3.2.2",
+  "version": "3.2.3",
   "packages": [
     "packages/*"
   ],

--- a/lerna.json
+++ b/lerna.json
@@ -1,7 +1,7 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
   "useWorkspaces": true,
-  "version": "3.2.4",
+  "version": "3.2.1",
   "packages": [
     "packages/*"
   ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -15232,7 +15232,7 @@
     },
     "packages/auth": {
       "name": "@multiversx/sdk-nestjs-auth",
-      "version": "3.2.0",
+      "version": "3.2.1",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@multiversx/sdk-core": "^12.15.0",
@@ -15256,7 +15256,7 @@
     },
     "packages/cache": {
       "name": "@multiversx/sdk-nestjs-cache",
-      "version": "3.2.0",
+      "version": "3.2.1",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "lru-cache": "^8.0.4",
@@ -15296,7 +15296,7 @@
     },
     "packages/common": {
       "name": "@multiversx/sdk-nestjs-common",
-      "version": "3.2.0",
+      "version": "3.2.1",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@multiversx/sdk-core": "^12.15.0",
@@ -15328,7 +15328,7 @@
     },
     "packages/elastic": {
       "name": "@multiversx/sdk-nestjs-elastic",
-      "version": "3.2.0",
+      "version": "3.2.1",
       "license": "GPL-3.0-or-later",
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^5.12.0",
@@ -15343,7 +15343,7 @@
     },
     "packages/http": {
       "name": "@multiversx/sdk-nestjs-http",
-      "version": "3.2.0",
+      "version": "3.2.1",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@multiversx/sdk-native-auth-client": "^1.0.7",
@@ -15367,7 +15367,7 @@
     },
     "packages/monitoring": {
       "name": "@multiversx/sdk-nestjs-monitoring",
-      "version": "3.2.0",
+      "version": "3.2.1",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "prom-client": "^14.0.1",
@@ -15386,7 +15386,7 @@
     },
     "packages/rabbitmq": {
       "name": "@multiversx/sdk-nestjs-rabbitmq",
-      "version": "3.2.0",
+      "version": "3.2.1",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@golevelup/nestjs-rabbitmq": "4.0.0",
@@ -15407,7 +15407,7 @@
     },
     "packages/redis": {
       "name": "@multiversx/sdk-nestjs-redis",
-      "version": "3.2.0",
+      "version": "3.2.1",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "ioredis": "^5.2.3"

--- a/package-lock.json
+++ b/package-lock.json
@@ -15232,7 +15232,7 @@
     },
     "packages/auth": {
       "name": "@multiversx/sdk-nestjs-auth",
-      "version": "3.2.4",
+      "version": "3.2.1",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@multiversx/sdk-core": "^12.15.0",
@@ -15256,7 +15256,7 @@
     },
     "packages/cache": {
       "name": "@multiversx/sdk-nestjs-cache",
-      "version": "3.2.4",
+      "version": "3.2.1",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "lru-cache": "^8.0.4",
@@ -15296,7 +15296,7 @@
     },
     "packages/common": {
       "name": "@multiversx/sdk-nestjs-common",
-      "version": "3.2.4",
+      "version": "3.2.1",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@multiversx/sdk-core": "^12.15.0",
@@ -15328,7 +15328,7 @@
     },
     "packages/elastic": {
       "name": "@multiversx/sdk-nestjs-elastic",
-      "version": "3.2.4",
+      "version": "3.2.1",
       "license": "GPL-3.0-or-later",
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^5.12.0",
@@ -15343,7 +15343,7 @@
     },
     "packages/http": {
       "name": "@multiversx/sdk-nestjs-http",
-      "version": "3.2.4",
+      "version": "3.2.1",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@multiversx/sdk-native-auth-client": "^1.0.7",
@@ -15367,7 +15367,7 @@
     },
     "packages/monitoring": {
       "name": "@multiversx/sdk-nestjs-monitoring",
-      "version": "3.2.4",
+      "version": "3.2.1",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "prom-client": "^14.0.1",
@@ -15386,7 +15386,7 @@
     },
     "packages/rabbitmq": {
       "name": "@multiversx/sdk-nestjs-rabbitmq",
-      "version": "3.2.4",
+      "version": "3.2.1",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@golevelup/nestjs-rabbitmq": "4.0.0",
@@ -15407,7 +15407,7 @@
     },
     "packages/redis": {
       "name": "@multiversx/sdk-nestjs-redis",
-      "version": "3.2.4",
+      "version": "3.2.1",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "ioredis": "^5.2.3"

--- a/package-lock.json
+++ b/package-lock.json
@@ -15232,7 +15232,7 @@
     },
     "packages/auth": {
       "name": "@multiversx/sdk-nestjs-auth",
-      "version": "3.2.2",
+      "version": "3.2.3",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@multiversx/sdk-core": "^12.15.0",
@@ -15256,7 +15256,7 @@
     },
     "packages/cache": {
       "name": "@multiversx/sdk-nestjs-cache",
-      "version": "3.2.2",
+      "version": "3.2.3",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "lru-cache": "^8.0.4",
@@ -15296,7 +15296,7 @@
     },
     "packages/common": {
       "name": "@multiversx/sdk-nestjs-common",
-      "version": "3.2.2",
+      "version": "3.2.3",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@multiversx/sdk-core": "^12.15.0",
@@ -15328,7 +15328,7 @@
     },
     "packages/elastic": {
       "name": "@multiversx/sdk-nestjs-elastic",
-      "version": "3.2.2",
+      "version": "3.2.3",
       "license": "GPL-3.0-or-later",
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^5.12.0",
@@ -15343,7 +15343,7 @@
     },
     "packages/http": {
       "name": "@multiversx/sdk-nestjs-http",
-      "version": "3.2.2",
+      "version": "3.2.3",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@multiversx/sdk-native-auth-client": "^1.0.7",
@@ -15367,7 +15367,7 @@
     },
     "packages/monitoring": {
       "name": "@multiversx/sdk-nestjs-monitoring",
-      "version": "3.2.2",
+      "version": "3.2.3",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "prom-client": "^14.0.1",
@@ -15386,7 +15386,7 @@
     },
     "packages/rabbitmq": {
       "name": "@multiversx/sdk-nestjs-rabbitmq",
-      "version": "3.2.2",
+      "version": "3.2.3",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@golevelup/nestjs-rabbitmq": "4.0.0",
@@ -15407,7 +15407,7 @@
     },
     "packages/redis": {
       "name": "@multiversx/sdk-nestjs-redis",
-      "version": "3.2.2",
+      "version": "3.2.3",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "ioredis": "^5.2.3"

--- a/package-lock.json
+++ b/package-lock.json
@@ -15232,7 +15232,7 @@
     },
     "packages/auth": {
       "name": "@multiversx/sdk-nestjs-auth",
-      "version": "3.2.1",
+      "version": "3.2.2",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@multiversx/sdk-core": "^12.15.0",
@@ -15256,7 +15256,7 @@
     },
     "packages/cache": {
       "name": "@multiversx/sdk-nestjs-cache",
-      "version": "3.2.1",
+      "version": "3.2.2",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "lru-cache": "^8.0.4",
@@ -15296,7 +15296,7 @@
     },
     "packages/common": {
       "name": "@multiversx/sdk-nestjs-common",
-      "version": "3.2.1",
+      "version": "3.2.2",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@multiversx/sdk-core": "^12.15.0",
@@ -15328,7 +15328,7 @@
     },
     "packages/elastic": {
       "name": "@multiversx/sdk-nestjs-elastic",
-      "version": "3.2.1",
+      "version": "3.2.2",
       "license": "GPL-3.0-or-later",
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^5.12.0",
@@ -15343,7 +15343,7 @@
     },
     "packages/http": {
       "name": "@multiversx/sdk-nestjs-http",
-      "version": "3.2.1",
+      "version": "3.2.2",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@multiversx/sdk-native-auth-client": "^1.0.7",
@@ -15367,7 +15367,7 @@
     },
     "packages/monitoring": {
       "name": "@multiversx/sdk-nestjs-monitoring",
-      "version": "3.2.1",
+      "version": "3.2.2",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "prom-client": "^14.0.1",
@@ -15386,7 +15386,7 @@
     },
     "packages/rabbitmq": {
       "name": "@multiversx/sdk-nestjs-rabbitmq",
-      "version": "3.2.1",
+      "version": "3.2.2",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@golevelup/nestjs-rabbitmq": "4.0.0",
@@ -15407,7 +15407,7 @@
     },
     "packages/redis": {
       "name": "@multiversx/sdk-nestjs-redis",
-      "version": "3.2.1",
+      "version": "3.2.2",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "ioredis": "^5.2.3"

--- a/package-lock.json
+++ b/package-lock.json
@@ -15232,7 +15232,7 @@
     },
     "packages/auth": {
       "name": "@multiversx/sdk-nestjs-auth",
-      "version": "3.2.3",
+      "version": "3.2.4",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@multiversx/sdk-core": "^12.15.0",
@@ -15256,7 +15256,7 @@
     },
     "packages/cache": {
       "name": "@multiversx/sdk-nestjs-cache",
-      "version": "3.2.3",
+      "version": "3.2.4",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "lru-cache": "^8.0.4",
@@ -15296,7 +15296,7 @@
     },
     "packages/common": {
       "name": "@multiversx/sdk-nestjs-common",
-      "version": "3.2.3",
+      "version": "3.2.4",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@multiversx/sdk-core": "^12.15.0",
@@ -15328,7 +15328,7 @@
     },
     "packages/elastic": {
       "name": "@multiversx/sdk-nestjs-elastic",
-      "version": "3.2.3",
+      "version": "3.2.4",
       "license": "GPL-3.0-or-later",
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^5.12.0",
@@ -15343,7 +15343,7 @@
     },
     "packages/http": {
       "name": "@multiversx/sdk-nestjs-http",
-      "version": "3.2.3",
+      "version": "3.2.4",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@multiversx/sdk-native-auth-client": "^1.0.7",
@@ -15367,7 +15367,7 @@
     },
     "packages/monitoring": {
       "name": "@multiversx/sdk-nestjs-monitoring",
-      "version": "3.2.3",
+      "version": "3.2.4",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "prom-client": "^14.0.1",
@@ -15386,7 +15386,7 @@
     },
     "packages/rabbitmq": {
       "name": "@multiversx/sdk-nestjs-rabbitmq",
-      "version": "3.2.3",
+      "version": "3.2.4",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@golevelup/nestjs-rabbitmq": "4.0.0",
@@ -15407,7 +15407,7 @@
     },
     "packages/redis": {
       "name": "@multiversx/sdk-nestjs-redis",
-      "version": "3.2.3",
+      "version": "3.2.4",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "ioredis": "^5.2.3"

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-nestjs-auth",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "description": "Multiversx SDK Nestjs auth package",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-nestjs-auth",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "Multiversx SDK Nestjs auth package",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-nestjs-auth",
-  "version": "3.2.3",
+  "version": "3.2.4",
   "description": "Multiversx SDK Nestjs auth package",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-nestjs-auth",
-  "version": "3.2.4",
+  "version": "3.2.1",
   "description": "Multiversx SDK Nestjs auth package",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-nestjs-auth",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "description": "Multiversx SDK Nestjs auth package",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-nestjs-cache",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "description": "Multiversx SDK Nestjs cache package",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-nestjs-cache",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "description": "Multiversx SDK Nestjs cache package",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-nestjs-cache",
-  "version": "3.2.4",
+  "version": "3.2.1",
   "description": "Multiversx SDK Nestjs cache package",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-nestjs-cache",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "Multiversx SDK Nestjs cache package",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-nestjs-cache",
-  "version": "3.2.3",
+  "version": "3.2.4",
   "description": "Multiversx SDK Nestjs cache package",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-nestjs-common",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "description": "Multiversx SDK Nestjs common package",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-nestjs-common",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "description": "Multiversx SDK Nestjs common package",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-nestjs-common",
-  "version": "3.2.4",
+  "version": "3.2.1",
   "description": "Multiversx SDK Nestjs common package",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-nestjs-common",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "Multiversx SDK Nestjs common package",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-nestjs-common",
-  "version": "3.2.3",
+  "version": "3.2.4",
   "description": "Multiversx SDK Nestjs common package",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/common/src/utils/origin.logger.ts
+++ b/packages/common/src/utils/origin.logger.ts
@@ -14,8 +14,14 @@ export class OriginLogger implements LoggerService {
     let actualContext = this.context;
 
     const trackedContext = ContextTracker.get();
-    if (trackedContext && trackedContext.origin) {
-      actualContext += ':' + trackedContext.origin;
+    if (trackedContext) {
+      if (trackedContext.origin) {
+        actualContext += ':' + trackedContext.origin;
+      }
+
+      if (trackedContext.requestId) {
+        actualContext += ':' + trackedContext.requestId;
+      }
     }
 
     return actualContext;

--- a/packages/elastic/package.json
+++ b/packages/elastic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-nestjs-elastic",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "description": "Multiversx SDK Nestjs elastic package",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/elastic/package.json
+++ b/packages/elastic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-nestjs-elastic",
-  "version": "3.2.3",
+  "version": "3.2.4",
   "description": "Multiversx SDK Nestjs elastic package",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/elastic/package.json
+++ b/packages/elastic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-nestjs-elastic",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "description": "Multiversx SDK Nestjs elastic package",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/elastic/package.json
+++ b/packages/elastic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-nestjs-elastic",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "Multiversx SDK Nestjs elastic package",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/elastic/package.json
+++ b/packages/elastic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-nestjs-elastic",
-  "version": "3.2.4",
+  "version": "3.2.1",
   "description": "Multiversx SDK Nestjs elastic package",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-nestjs-http",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "description": "Multiversx SDK Nestjs http package",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-nestjs-http",
-  "version": "3.2.3",
+  "version": "3.2.4",
   "description": "Multiversx SDK Nestjs http package",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-nestjs-http",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "description": "Multiversx SDK Nestjs http package",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-nestjs-http",
-  "version": "3.2.4",
+  "version": "3.2.1",
   "description": "Multiversx SDK Nestjs http package",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-nestjs-http",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "Multiversx SDK Nestjs http package",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/http/src/api/api.service.ts
+++ b/packages/http/src/api/api.service.ts
@@ -53,7 +53,6 @@ export class ApiService {
 
     const context = ContextTracker.get();
     if (context && context.requestId) {
-      console.log(`setting request id to ${context.requestId} to perform request`);
       headers['x-request-id'] = context.requestId;
     }
 

--- a/packages/http/src/api/api.service.ts
+++ b/packages/http/src/api/api.service.ts
@@ -4,7 +4,7 @@ import Agent from "agentkeepalive";
 import { PerformanceProfiler, MetricsService } from "@multiversx/sdk-nestjs-monitoring";
 import { ApiSettings } from "./entities/api.settings";
 import { ApiModuleOptions } from "./entities/api.module.options";
-import { PendingExecuter } from "@multiversx/sdk-nestjs-common";
+import { ContextTracker, PendingExecuter } from "@multiversx/sdk-nestjs-common";
 
 @Injectable()
 export class ApiService {
@@ -49,6 +49,12 @@ export class ApiService {
     if (settings.nativeAuthSigner) {
       const accessTokenInfo = await settings.nativeAuthSigner.getToken();
       headers['authorization'] = `Bearer ${accessTokenInfo.token}`;
+    }
+
+    const context = ContextTracker.get();
+    if (context && context.requestId) {
+      console.log(`setting request id to ${context.requestId} to perform request`);
+      headers['x-request-id'] = context.requestId;
     }
 
     return {

--- a/packages/http/src/interceptors/origin.interceptor.ts
+++ b/packages/http/src/interceptors/origin.interceptor.ts
@@ -13,8 +13,9 @@ export class OriginInterceptor implements NestInterceptor {
     }
 
     const apiFunction = context.getClass().name + '.' + context.getHandler().name;
+    const requestId = context.switchToHttp().getRequest().headers['x-request-id'] ?? crypto.randomUUID();
 
-    ContextTracker.assign({ origin: apiFunction });
+    ContextTracker.assign({ origin: apiFunction, requestId });
 
     return next
       .handle()

--- a/packages/http/src/interceptors/origin.interceptor.ts
+++ b/packages/http/src/interceptors/origin.interceptor.ts
@@ -2,6 +2,7 @@ import { CallHandler, ExecutionContext, Injectable, NestInterceptor } from "@nes
 import { Observable, throwError } from "rxjs";
 import { catchError, tap } from 'rxjs/operators';
 import { ContextTracker } from "@multiversx/sdk-nestjs-common";
+import { randomUUID } from 'crypto';
 
 @Injectable()
 export class OriginInterceptor implements NestInterceptor {
@@ -14,7 +15,7 @@ export class OriginInterceptor implements NestInterceptor {
 
     const apiFunction = context.getClass().name + '.' + context.getHandler().name;
     const request = context.switchToHttp().getRequest();
-    const requestId = request.headers['x-request-id'] ?? crypto.randomUUID();
+    const requestId = request.headers['x-request-id'] ?? randomUUID();
 
     ContextTracker.assign({ origin: apiFunction, requestId });
 

--- a/packages/monitoring/package.json
+++ b/packages/monitoring/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-nestjs-monitoring",
-  "version": "3.2.3",
+  "version": "3.2.4",
   "description": "Multiversx SDK Nestjs monitoring package",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/monitoring/package.json
+++ b/packages/monitoring/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-nestjs-monitoring",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "Multiversx SDK Nestjs monitoring package",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/monitoring/package.json
+++ b/packages/monitoring/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-nestjs-monitoring",
-  "version": "3.2.4",
+  "version": "3.2.1",
   "description": "Multiversx SDK Nestjs monitoring package",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/monitoring/package.json
+++ b/packages/monitoring/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-nestjs-monitoring",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "description": "Multiversx SDK Nestjs monitoring package",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/monitoring/package.json
+++ b/packages/monitoring/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-nestjs-monitoring",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "description": "Multiversx SDK Nestjs monitoring package",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/rabbitmq/package.json
+++ b/packages/rabbitmq/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-nestjs-rabbitmq",
-  "version": "3.2.3",
+  "version": "3.2.4",
   "description": "Multiversx SDK Nestjs rabbitmq client package",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/rabbitmq/package.json
+++ b/packages/rabbitmq/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-nestjs-rabbitmq",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "description": "Multiversx SDK Nestjs rabbitmq client package",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/rabbitmq/package.json
+++ b/packages/rabbitmq/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-nestjs-rabbitmq",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "Multiversx SDK Nestjs rabbitmq client package",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/rabbitmq/package.json
+++ b/packages/rabbitmq/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-nestjs-rabbitmq",
-  "version": "3.2.4",
+  "version": "3.2.1",
   "description": "Multiversx SDK Nestjs rabbitmq client package",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/rabbitmq/package.json
+++ b/packages/rabbitmq/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-nestjs-rabbitmq",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "description": "Multiversx SDK Nestjs rabbitmq client package",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/redis/package.json
+++ b/packages/redis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-nestjs-redis",
-  "version": "3.2.4",
+  "version": "3.2.1",
   "description": "Multiversx SDK Nestjs redis client package",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/redis/package.json
+++ b/packages/redis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-nestjs-redis",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "description": "Multiversx SDK Nestjs redis client package",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/redis/package.json
+++ b/packages/redis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-nestjs-redis",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "Multiversx SDK Nestjs redis client package",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/redis/package.json
+++ b/packages/redis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-nestjs-redis",
-  "version": "3.2.3",
+  "version": "3.2.4",
   "description": "Multiversx SDK Nestjs redis client package",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/redis/package.json
+++ b/packages/redis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-nestjs-redis",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "description": "Multiversx SDK Nestjs redis client package",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",


### PR DESCRIPTION
Reasoning:
- tracing errors back to a request that has been performed might be a bit tricky

What's changed:
- the `OriginInterceptor` component not only propagates the controller function called, but also generates a uuid (or passes the one received in the headers) which is in turn used by the `OriginLogger` to also log that requestId in the message
- the `ApiService` component it aware of the `requestId` which it propagates to the downstream service. In this way, a unified log across multiple microservices can be built.

How to test
- with `OriginInterceptor` attached, use the `OriginLogger` to log some messages. they should reference the same `requestId` that is sent in the response headers
- all requests performed using the `ApiService` component should contain the `x-request-id` header set for downstream service calls