### PR TITLE
Redis hash operations

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,7 +1,7 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
   "useWorkspaces": true,
-  "version": "4.1.0",
+  "version": "4.2.0",
   "packages": [
     "packages/*"
   ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -13100,7 +13100,7 @@
     },
     "packages/auth": {
       "name": "@multiversx/sdk-nestjs-auth",
-      "version": "4.1.0",
+      "version": "4.2.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@multiversx/sdk-core": "^13.15.0",
@@ -13123,7 +13123,7 @@
     },
     "packages/cache": {
       "name": "@multiversx/sdk-nestjs-cache",
-      "version": "4.1.0",
+      "version": "4.2.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "lru-cache": "^8.0.4",
@@ -13162,7 +13162,7 @@
     },
     "packages/common": {
       "name": "@multiversx/sdk-nestjs-common",
-      "version": "4.1.0",
+      "version": "4.2.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@multiversx/sdk-core": "^13.5.0",
@@ -13193,7 +13193,7 @@
     },
     "packages/elastic": {
       "name": "@multiversx/sdk-nestjs-elastic",
-      "version": "4.1.0",
+      "version": "4.2.0",
       "license": "GPL-3.0-or-later",
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^5.12.0",
@@ -13208,7 +13208,7 @@
     },
     "packages/http": {
       "name": "@multiversx/sdk-nestjs-http",
-      "version": "4.1.0",
+      "version": "4.2.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@multiversx/sdk-native-auth-client": "^1.0.9",
@@ -13232,7 +13232,7 @@
     },
     "packages/monitoring": {
       "name": "@multiversx/sdk-nestjs-monitoring",
-      "version": "4.1.0",
+      "version": "4.2.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "prom-client": "^14.0.1",
@@ -13251,7 +13251,7 @@
     },
     "packages/rabbitmq": {
       "name": "@multiversx/sdk-nestjs-rabbitmq",
-      "version": "4.1.0",
+      "version": "4.2.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@golevelup/nestjs-rabbitmq": "4.0.0",
@@ -13272,7 +13272,7 @@
     },
     "packages/redis": {
       "name": "@multiversx/sdk-nestjs-redis",
-      "version": "4.1.0",
+      "version": "4.2.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "ioredis": "^5.2.3"

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-nestjs-auth",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "description": "Multiversx SDK Nestjs auth package",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-nestjs-cache",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "description": "Multiversx SDK Nestjs cache package",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/cache/src/cache/cache.service.ts
+++ b/packages/cache/src/cache/cache.service.ts
@@ -478,6 +478,43 @@ export class CacheService {
     return await this.redisCacheService.scard(key);
   }
 
+  async hashGetRemote<T>(hash: string, field: string): Promise<T | null> {
+    return await this.redisCacheService.hget<T>(hash, field);
+  }
+
+  async hashGetAllRemote(hash: string): Promise<Record<string, any> | null> {
+    return await this.redisCacheService.hgetall(hash);
+  }
+
+  async hashSetRemote<T>(
+    hash: string,
+    field: string,
+    value: T,
+    cacheNullable: boolean = true,
+  ): Promise<number> {
+    return await this.redisCacheService.hset<T>(hash, field, value, cacheNullable);
+  }
+
+  async hashSetManyRemote(
+    hash: string,
+    fieldsValues: [string, any][],
+    cacheNullable: boolean = true,
+  ): Promise<number> {
+    return await this.redisCacheService.hsetMany(hash, fieldsValues, cacheNullable);
+  }
+
+  async hashIncrementRemote(
+    hash: string,
+    field: string,
+    increment: number | string,
+  ): Promise<number> {
+    return await this.redisCacheService.hincrby(hash, field, increment);
+  }
+
+  async hashKeysRemote(hash: string): Promise<string[]> {
+    return await this.redisCacheService.hkeys(hash);
+  }
+
   async batchSet(keys: string[], values: any[], ttls: number[], setLocalCache: boolean = true, spreadTtl: boolean = true) {
     if (!ttls) {
       ttls = new Array(keys.length).fill(this.getCacheTtl());

--- a/packages/cache/src/redis-cache/options.ts
+++ b/packages/cache/src/redis-cache/options.ts
@@ -14,6 +14,8 @@ export class RedisCacheModuleOptions {
     name?: string | undefined;
     tls?: ConnectionOptions | undefined;
     db?: number | undefined;
+    enableAutoPipelining?: boolean | undefined;
+    autoPipeliningIgnoredCommands?: string[] | undefined;
   };
 
   additionalOptions?: {

--- a/packages/cache/src/redis-cache/redis-cache.service.ts
+++ b/packages/cache/src/redis-cache/redis-cache.service.ts
@@ -389,9 +389,9 @@ export class RedisCacheService {
     return null;
   }
 
-  async hgetall<T>(
+  async hgetall(
     hash: string,
-  ): Promise<Record<string, T> | null> {
+  ): Promise<Record<string, any> | null> {
     const performanceProfiler = new PerformanceProfiler();
     try {
       const data = await this.redis.hgetall(hash);
@@ -399,7 +399,7 @@ export class RedisCacheService {
         return null;
       }
 
-      const response: Record<string, T> = {};
+      const response: Record<string, any> = {};
       for (const key of Object.keys(data)) {
         response[key] = JSON.parse(data[key]);
       }

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-nestjs-common",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "description": "Multiversx SDK Nestjs common package",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/elastic/package.json
+++ b/packages/elastic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-nestjs-elastic",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "description": "Multiversx SDK Nestjs elastic package",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-nestjs-http",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "description": "Multiversx SDK Nestjs http package",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/monitoring/package.json
+++ b/packages/monitoring/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-nestjs-monitoring",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "description": "Multiversx SDK Nestjs monitoring package",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/rabbitmq/package.json
+++ b/packages/rabbitmq/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-nestjs-rabbitmq",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "description": "Multiversx SDK Nestjs rabbitmq client package",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/redis/package.json
+++ b/packages/redis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-nestjs-redis",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "description": "Multiversx SDK Nestjs redis client package",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",


### PR DESCRIPTION
- add Redis cache pipelining options
- add method ( `hsetMany`) for setting multiple hash fields to Redis cache service
- expose Redis hash operations in Cache Service 