### PR TITLE
remove promisfy

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,14 @@
+## Reasoning
+- 
+- 
+- 
+  
+## Proposed Changes
+- 
+- 
+- 
+
+## How to test
+- 
+- 
+- 

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "packages": [
     "packages/*"
   ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -14269,7 +14269,7 @@
     },
     "packages/auth": {
       "name": "@multiversx/sdk-nestjs-auth",
-      "version": "7.0.0",
+      "version": "7.0.1",
       "license": "MIT",
       "dependencies": {
         "@multiversx/sdk-core": "^15.4.0",
@@ -14292,7 +14292,7 @@
     },
     "packages/cache": {
       "name": "@multiversx/sdk-nestjs-cache",
-      "version": "7.0.0",
+      "version": "7.0.1",
       "license": "MIT",
       "dependencies": {
         "lru-cache": "^11.3.5",
@@ -14353,7 +14353,7 @@
     },
     "packages/common": {
       "name": "@multiversx/sdk-nestjs-common",
-      "version": "7.0.0",
+      "version": "7.0.1",
       "license": "MIT",
       "dependencies": {
         "@multiversx/sdk-core": "^15.4.0",
@@ -14407,7 +14407,7 @@
     },
     "packages/elastic": {
       "name": "@multiversx/sdk-nestjs-elastic",
-      "version": "7.0.0",
+      "version": "7.0.1",
       "license": "MIT",
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^8.59.0",
@@ -14422,7 +14422,7 @@
     },
     "packages/http": {
       "name": "@multiversx/sdk-nestjs-http",
-      "version": "7.0.0",
+      "version": "7.0.1",
       "license": "MIT",
       "dependencies": {
         "@multiversx/sdk-core": "^15.4.0",
@@ -14447,7 +14447,7 @@
     },
     "packages/monitoring": {
       "name": "@multiversx/sdk-nestjs-monitoring",
-      "version": "7.0.0",
+      "version": "7.0.1",
       "license": "MIT",
       "dependencies": {
         "prom-client": "^15.1.3",
@@ -14466,7 +14466,7 @@
     },
     "packages/rabbitmq": {
       "name": "@multiversx/sdk-nestjs-rabbitmq",
-      "version": "7.0.0",
+      "version": "7.0.1",
       "license": "MIT",
       "dependencies": {
         "@golevelup/nestjs-rabbitmq": "9.0.0",
@@ -14498,7 +14498,7 @@
     },
     "packages/redis": {
       "name": "@multiversx/sdk-nestjs-redis",
-      "version": "7.0.0",
+      "version": "7.0.1",
       "license": "MIT",
       "dependencies": {
         "ioredis": "^5.10.1"

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-nestjs-auth",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "description": "Multiversx SDK Nestjs auth package",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-nestjs-cache",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "description": "Multiversx SDK Nestjs cache package",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/cache/src/redis-cache/redis-cache.service.ts
+++ b/packages/cache/src/redis-cache/redis-cache.service.ts
@@ -3,7 +3,6 @@ import { Inject, Injectable } from '@nestjs/common';
 import { MetricsService, PerformanceProfiler } from '@multiversx/sdk-nestjs-monitoring';
 import { OriginLogger } from '@multiversx/sdk-nestjs-common';
 import { REDIS_CLIENT_TOKEN } from '@multiversx/sdk-nestjs-redis';
-import { promisify } from 'util';
 
 @Injectable()
 export class RedisCacheService {
@@ -1002,9 +1001,12 @@ export class RedisCacheService {
   asyncMulti = async (commands: any[]) => {
     const profiler = new PerformanceProfiler();
     const multi = this.redis.multi(commands);
-    const data = await promisify(multi.exec).call(multi);
-    this.metricsService.setRedisDuration('MULTI', profiler.duration);
-    return data;
+    try {
+      const data = await multi.exec();
+      return data;
+    } finally {
+      this.metricsService.setRedisDuration('MULTI', profiler.duration);
+    }
   };
 
 }

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-nestjs-common",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "description": "Multiversx SDK Nestjs common package",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/elastic/package.json
+++ b/packages/elastic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-nestjs-elastic",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "description": "Multiversx SDK Nestjs elastic package",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-nestjs-http",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "description": "Multiversx SDK Nestjs http package",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/monitoring/package.json
+++ b/packages/monitoring/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-nestjs-monitoring",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "description": "Multiversx SDK Nestjs monitoring package",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/rabbitmq/package.json
+++ b/packages/rabbitmq/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-nestjs-rabbitmq",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "description": "Multiversx SDK Nestjs rabbitmq client package",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/redis/package.json
+++ b/packages/redis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-nestjs-redis",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "description": "Multiversx SDK Nestjs redis client package",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",


### PR DESCRIPTION
## Reasoning
- Eliminate Node `DEP0174` warning
- Modernize `multi.exec` usage
- Keep metrics timing reliable

## Proposed Changes
- Replace `promisify(multi.exec)` with `await multi.exec()`
- Record `MULTI` metric in `finally`
- Small, localized change in `redis-cache.service.ts`

## How to test
- Run cache tests: `cd packages/cache && npm test`
- Trigger bulk cache ops (e.g. `setMany`, `deleteByPattern`)
- Verify no `DEP0174` warning and `MULTI` metric logged