### PR TITLE
Upgrade publish action

### DIFF
--- a/.github/workflows/npm-publish-specific-package-not-main.yml
+++ b/.github/workflows/npm-publish-specific-package-not-main.yml
@@ -49,8 +49,6 @@ jobs:
           fi
 
       - name: Publish to npmjs
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           if [ -z "${{ github.event.inputs.package_name }}" ]; then
             echo "Publishing all changed packages..."

--- a/.github/workflows/npm-publish-specific-package-not-main.yml
+++ b/.github/workflows/npm-publish-specific-package-not-main.yml
@@ -15,7 +15,8 @@ on:
         required: false
 
 permissions:
-  contents: write
+  contents: read
+  id-token: write
 
 jobs:
   publish-npm:

--- a/.github/workflows/publish-not-main.yml
+++ b/.github/workflows/publish-not-main.yml
@@ -11,7 +11,8 @@ on:
           - beta
 
 permissions:
-  contents: write
+  contents: read
+  id-token: write
 
 jobs:
   publish-npm:

--- a/.github/workflows/publish-not-main.yml
+++ b/.github/workflows/publish-not-main.yml
@@ -44,6 +44,4 @@ jobs:
           gh release create --prerelease $RELEASE_TAG --target=$GITHUB_SHA --title="$RELEASE_TAG" --generate-notes
 
       - name: Publish to npmjs
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
         run: npx lerna publish from-package --yes --dist-tag ${{ github.event.inputs.channel }} --pre-dist-tag ${{ github.event.inputs.channel }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,6 +43,4 @@ jobs:
           gh release create $RELEASE_TAG --target=$GITHUB_SHA --title="$RELEASE_TAG" --generate-notes --notes-file=notes.txt
 
       - name: Publish to npmjs
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
         run: npx lerna publish from-package --yes

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,7 +4,8 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
+  id-token: write
 
 jobs:
   common:

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -43,6 +43,7 @@
     "@nestjs/common": "^11.x"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -46,6 +46,7 @@
     "@nestjs/core": "^11.x"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -46,6 +46,7 @@
     "@nestjs/swagger": "^11.x"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/elastic/package.json
+++ b/packages/elastic/package.json
@@ -35,6 +35,7 @@
     "@nestjs/common": "^11.x"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -45,6 +45,7 @@
     "@nestjs/core": "^11.x"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/monitoring/package.json
+++ b/packages/monitoring/package.json
@@ -39,6 +39,7 @@
     "@nestjs/common": "^11.x"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/rabbitmq/package.json
+++ b/packages/rabbitmq/package.json
@@ -41,6 +41,7 @@
     "@nestjs/common": "^11.x"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/redis/package.json
+++ b/packages/redis/package.json
@@ -38,6 +38,7 @@
     "@nestjs/common": "^11.x"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   }
 }


### PR DESCRIPTION
## Reasoning
- Update the publishing flow to use npm provenance and OIDC-based publishing.
- Remove the NPM token from `secrets.env` and align package manifests with the new release setup.

## Proposed Changes
- Add `"provenance": true` under `publishConfig` in all publishable package manifests.
- Update the GitHub Actions publish workflows to use the new npm publishing permissions.
- Remove the NPM token from `secrets.env`.

## How to test
- Run the publish workflow in GitHub Actions.
- Confirm all packages publish successfully to npm with provenance enabled.