### PR TITLE
contents write permission

### DIFF
--- a/.github/workflows/npm-publish-specific-package-not-main.yml
+++ b/.github/workflows/npm-publish-specific-package-not-main.yml
@@ -15,7 +15,7 @@ on:
         required: false
 
 permissions:
-  contents: read
+  contents: write
   id-token: write
 
 jobs:

--- a/.github/workflows/publish-not-main.yml
+++ b/.github/workflows/publish-not-main.yml
@@ -11,7 +11,7 @@ on:
           - beta
 
 permissions:
-  contents: read
+  contents: write
   id-token: write
 
 jobs:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
   id-token: write
 
 jobs:


### PR DESCRIPTION
## Reasoning
- Grant GitHub Actions write access to repository contents so workflows can create releases, push tags, and update release assets.

## Proposed Changes
- Set `permissions.contents: write` in the publish workflow files.

## How to test
- Run the publish workflow manually.
- Verify release creation, tag push, or any steps that modify repo contents succeed.