### PR TITLE
Elastic Prefix Query Support

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "7.1.0",
+  "version": "7.2.0",
   "packages": [
     "packages/*"
   ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -14268,7 +14268,7 @@
     },
     "packages/auth": {
       "name": "@multiversx/sdk-nestjs-auth",
-      "version": "7.1.0",
+      "version": "7.2.0",
       "license": "MIT",
       "dependencies": {
         "@multiversx/sdk-core": "^15.4.0",
@@ -14291,7 +14291,7 @@
     },
     "packages/cache": {
       "name": "@multiversx/sdk-nestjs-cache",
-      "version": "7.1.0",
+      "version": "7.2.0",
       "license": "MIT",
       "dependencies": {
         "lru-cache": "^11.3.5",
@@ -14352,7 +14352,7 @@
     },
     "packages/common": {
       "name": "@multiversx/sdk-nestjs-common",
-      "version": "7.1.0",
+      "version": "7.2.0",
       "license": "MIT",
       "dependencies": {
         "@multiversx/sdk-core": "^15.4.0",
@@ -14406,7 +14406,7 @@
     },
     "packages/elastic": {
       "name": "@multiversx/sdk-nestjs-elastic",
-      "version": "7.1.0",
+      "version": "7.2.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^24.1.0",
@@ -14439,7 +14439,7 @@
     },
     "packages/http": {
       "name": "@multiversx/sdk-nestjs-http",
-      "version": "7.1.0",
+      "version": "7.2.0",
       "license": "MIT",
       "dependencies": {
         "@multiversx/sdk-core": "^15.4.0",
@@ -14464,7 +14464,7 @@
     },
     "packages/monitoring": {
       "name": "@multiversx/sdk-nestjs-monitoring",
-      "version": "7.1.0",
+      "version": "7.2.0",
       "license": "MIT",
       "dependencies": {
         "prom-client": "^15.1.3",
@@ -14483,7 +14483,7 @@
     },
     "packages/rabbitmq": {
       "name": "@multiversx/sdk-nestjs-rabbitmq",
-      "version": "7.1.0",
+      "version": "7.2.0",
       "license": "MIT",
       "dependencies": {
         "@golevelup/nestjs-rabbitmq": "9.0.0",
@@ -14515,7 +14515,7 @@
     },
     "packages/redis": {
       "name": "@multiversx/sdk-nestjs-redis",
-      "version": "7.1.0",
+      "version": "7.2.0",
       "license": "MIT",
       "dependencies": {
         "ioredis": "^5.10.1"

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-nestjs-auth",
-  "version": "7.1.0",
+  "version": "7.2.0",
   "description": "Multiversx SDK Nestjs auth package",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-nestjs-cache",
-  "version": "7.1.0",
+  "version": "7.2.0",
   "description": "Multiversx SDK Nestjs cache package",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-nestjs-common",
-  "version": "7.1.0",
+  "version": "7.2.0",
   "description": "Multiversx SDK Nestjs common package",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/elastic/package.json
+++ b/packages/elastic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-nestjs-elastic",
-  "version": "7.1.0",
+  "version": "7.2.0",
   "description": "Multiversx SDK Nestjs elastic package",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/elastic/src/entities/elastic.query.ts
+++ b/packages/elastic/src/entities/elastic.query.ts
@@ -89,6 +89,22 @@ export class ElasticQuery {
     return this.withMustNotCondition(QueryType.Exists(key));
   }
 
+  withMustPrefixCondition(key: string, value: string | undefined): ElasticQuery {
+    if (value === undefined) {
+      return this;
+    }
+
+    return this.withMustCondition(QueryType.Prefix(key, value.toLowerCase()));
+  }
+
+  withMustNotPrefixCondition(key: string, value: string | undefined): ElasticQuery {
+    if (value === undefined) {
+      return this;
+    }
+
+    return this.withMustNotCondition(QueryType.Prefix(key, value.toLowerCase()));
+  }
+
   withMustCondition(queries: AbstractQuery[] | AbstractQuery): ElasticQuery {
     return this.withCondition(QueryConditionOptions.must, queries);
   }

--- a/packages/elastic/src/entities/prefix.query.ts
+++ b/packages/elastic/src/entities/prefix.query.ts
@@ -1,0 +1,21 @@
+import { AbstractQuery } from './abstract.query';
+
+export class PrefixQuery extends AbstractQuery {
+  constructor(
+    private readonly key: string,
+    private readonly value: string,
+  ) {
+    super();
+  }
+
+  getQuery(): any {
+    return {
+      prefix: {
+        [this.key]: {
+          value: this.value,
+          case_insensitive: true,
+        },
+      },
+    };
+  }
+}

--- a/packages/elastic/src/entities/query.type.ts
+++ b/packages/elastic/src/entities/query.type.ts
@@ -10,6 +10,7 @@ import { ShouldQuery } from "./should.query";
 import { WildcardQuery } from "./wildcard.query";
 import { StringQuery } from "./string.query";
 import { NestedShouldQuery } from "./nested.should.query";
+import { PrefixQuery } from './prefix.query';
 import { ScriptQuery } from "./script.query";
 
 export class QueryType {
@@ -27,6 +28,10 @@ export class QueryType {
 
   static Wildcard = (key: string, value: string): WildcardQuery => {
     return new WildcardQuery(key, value);
+  };
+
+  static Prefix = (key: string, value: string): PrefixQuery => {
+    return new PrefixQuery(key, value);
   };
 
   static Nested = (key: string, value: MatchQuery[]): NestedQuery => {

--- a/packages/elastic/src/index.ts
+++ b/packages/elastic/src/index.ts
@@ -26,3 +26,4 @@ export * from './entities/range.query';
 export * from './entities/should.query';
 export * from './entities/terms.query';
 export * from './entities/wildcard.query';
+export * from './entities/prefix.query';

--- a/packages/elastic/test/elastic.utils.spec.ts
+++ b/packages/elastic/test/elastic.utils.spec.ts
@@ -6,6 +6,7 @@ import { RangeLowerThanOrEqual } from "../src/entities/range.lower.than.or.equal
 import { TermsQuery } from "../src/entities/terms.query";
 import { ElasticQuery } from "../src/entities/elastic.query";
 import { AbstractQuery } from "../lib/entities/abstract.query";
+import { PrefixQuery } from "../src/entities/prefix.query";
 
 describe('Elastic Query', () => {
   describe('Create Elastic Query', () => {
@@ -119,5 +120,52 @@ describe('Elastic Query', () => {
     expect(elasticQuery.toJson().query.bool.must[2].nested.query.bool.should[0].wildcard).toBeDefined();
     expect(elasticQuery.toJson().query.bool.must[2].nested.query.bool.should[0].wildcard["data.name"].value).toBe('*day one*');
     expect(elasticQuery.toJson().query.bool.must[2].nested.query.bool.should[1].wildcard["data.token"].value).toBe('*day one*');
+  });
+
+  describe('Prefix Query', () => {
+    it('should create a prefix query', () => {
+      const query = new PrefixQuery('user', 'ki');
+      expect(query.getQuery()).toEqual({
+        prefix: {
+          user: {
+            value: 'ki',
+            case_insensitive: true,
+          },
+        },
+      });
+    });
+  
+    it('should create a prefix query and add it to elastic query', () => {
+      const elasticQuery = ElasticQuery.create();
+      elasticQuery.withCondition(QueryConditionOptions.must, [new PrefixQuery('user', 'ki')]);
+
+      expect(elasticQuery.condition.must.length).toEqual(1);
+      expect(elasticQuery.condition.must[0].getQuery()).toMatchObject({
+        prefix: {
+          user: {
+            value: 'ki',
+            case_insensitive: true,
+          },
+        },
+      });
+      expect(elasticQuery.toJson().query.bool.must).toBeDefined();
+
+      expect(elasticQuery.toJson()).toEqual({
+        query: {
+          bool: {
+            must: [
+              {
+                prefix: {
+                  user: {
+                    value: 'ki',
+                    case_insensitive: true,
+                  },
+                },
+              },
+            ],
+          },
+        },
+      });
+    });
   });
 });

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-nestjs-http",
-  "version": "7.1.0",
+  "version": "7.2.0",
   "description": "Multiversx SDK Nestjs http package",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/monitoring/package.json
+++ b/packages/monitoring/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-nestjs-monitoring",
-  "version": "7.1.0",
+  "version": "7.2.0",
   "description": "Multiversx SDK Nestjs monitoring package",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/rabbitmq/package.json
+++ b/packages/rabbitmq/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-nestjs-rabbitmq",
-  "version": "7.1.0",
+  "version": "7.2.0",
   "description": "Multiversx SDK Nestjs rabbitmq client package",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/redis/package.json
+++ b/packages/redis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-nestjs-redis",
-  "version": "7.1.0",
+  "version": "7.2.0",
   "description": "Multiversx SDK Nestjs redis client package",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",


### PR DESCRIPTION
## Reasoning
This change introduces support for prefix queries within the Elastic SDK, enhancing search capabilities by allowing users to query for documents based on a prefix of a term.

## Proposed Changes
- Added functionality for prefix queries to the Elastic SDK.

## How to test
- Run the existing unit tests for the `elastic` package: ``npm test packages/elastic``.
- Specifically verify the tests within ``elastic.utils.spec.ts`` that cover the new prefix query functionality.