### PR TITLE
Elastic security fixes

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "7.2.0",
+  "version": "7.2.1",
   "packages": [
     "packages/*"
   ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -14268,7 +14268,7 @@
     },
     "packages/auth": {
       "name": "@multiversx/sdk-nestjs-auth",
-      "version": "7.2.0",
+      "version": "7.2.1",
       "license": "MIT",
       "dependencies": {
         "@multiversx/sdk-core": "^15.4.0",
@@ -14291,7 +14291,7 @@
     },
     "packages/cache": {
       "name": "@multiversx/sdk-nestjs-cache",
-      "version": "7.2.0",
+      "version": "7.2.1",
       "license": "MIT",
       "dependencies": {
         "lru-cache": "^11.3.5",
@@ -14352,7 +14352,7 @@
     },
     "packages/common": {
       "name": "@multiversx/sdk-nestjs-common",
-      "version": "7.2.0",
+      "version": "7.2.1",
       "license": "MIT",
       "dependencies": {
         "@multiversx/sdk-core": "^15.4.0",
@@ -14406,7 +14406,7 @@
     },
     "packages/elastic": {
       "name": "@multiversx/sdk-nestjs-elastic",
-      "version": "7.2.0",
+      "version": "7.2.1",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^24.1.0",
@@ -14439,7 +14439,7 @@
     },
     "packages/http": {
       "name": "@multiversx/sdk-nestjs-http",
-      "version": "7.2.0",
+      "version": "7.2.1",
       "license": "MIT",
       "dependencies": {
         "@multiversx/sdk-core": "^15.4.0",
@@ -14464,7 +14464,7 @@
     },
     "packages/monitoring": {
       "name": "@multiversx/sdk-nestjs-monitoring",
-      "version": "7.2.0",
+      "version": "7.2.1",
       "license": "MIT",
       "dependencies": {
         "prom-client": "^15.1.3",
@@ -14483,7 +14483,7 @@
     },
     "packages/rabbitmq": {
       "name": "@multiversx/sdk-nestjs-rabbitmq",
-      "version": "7.2.0",
+      "version": "7.2.1",
       "license": "MIT",
       "dependencies": {
         "@golevelup/nestjs-rabbitmq": "9.0.0",
@@ -14515,7 +14515,7 @@
     },
     "packages/redis": {
       "name": "@multiversx/sdk-nestjs-redis",
-      "version": "7.2.0",
+      "version": "7.2.1",
       "license": "MIT",
       "dependencies": {
         "ioredis": "^5.10.1"

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-nestjs-auth",
-  "version": "7.2.0",
+  "version": "7.2.1",
   "description": "Multiversx SDK Nestjs auth package",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-nestjs-cache",
-  "version": "7.2.0",
+  "version": "7.2.1",
   "description": "Multiversx SDK Nestjs cache package",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-nestjs-common",
-  "version": "7.2.0",
+  "version": "7.2.1",
   "description": "Multiversx SDK Nestjs common package",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/elastic/package.json
+++ b/packages/elastic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-nestjs-elastic",
-  "version": "7.2.0",
+  "version": "7.2.1",
   "description": "Multiversx SDK Nestjs elastic package",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/elastic/src/elastic.service.ts
+++ b/packages/elastic/src/elastic.service.ts
@@ -14,30 +14,58 @@ export class ElasticService {
     private readonly metricsService: MetricsService,
   ) { }
 
+  private encodePathSegment(segment: string): string {
+    return encodeURIComponent(segment).replace(/%2C/g, ',');
+  }
+
   private buildElasticUrl(baseUrl: string, pathSegments: string[], queryParams?: Record<string, string | number | boolean | undefined>): string {
-    // Build URLs through the URL API so path segments are encoded instead of concatenated raw.
-    const parsedUrl = new URL(baseUrl);
+    const encodedPath = pathSegments.map(segment => this.encodePathSegment(segment)).join('/');
+    const appendPath = (basePath: string) => {
+      if (!encodedPath) {
+        return basePath;
+      }
 
-    const basePath = parsedUrl.pathname.endsWith('/') ? parsedUrl.pathname.slice(0, -1) : parsedUrl.pathname;
-    const encodedPath = pathSegments.map(segment => encodeURIComponent(segment)).join('/');
+      if (!basePath) {
+        return `/${encodedPath}`;
+      }
 
-    parsedUrl.pathname = [basePath, encodedPath].filter(Boolean).join('/');
-    parsedUrl.search = '';
-    parsedUrl.hash = '';
+      return basePath.endsWith('/') ? `${basePath}${encodedPath}` : `${basePath}/${encodedPath}`;
+    };
+
+    if (baseUrl.startsWith('http://') || baseUrl.startsWith('https://')) {
+      const parsedUrl = new URL(baseUrl);
+      parsedUrl.pathname = appendPath(parsedUrl.pathname);
+
+      if (queryParams) {
+        for (const [key, value] of Object.entries(queryParams)) {
+          if (value !== undefined) {
+            parsedUrl.searchParams.set(key, String(value));
+          }
+        }
+      }
+
+      return parsedUrl.toString();
+    }
+
+    const queryIndex = baseUrl.indexOf('?');
+    const basePath = queryIndex >= 0 ? baseUrl.slice(0, queryIndex) : baseUrl;
+    const existingQuery = queryIndex >= 0 ? baseUrl.slice(queryIndex + 1) : '';
+    const searchParams = new URLSearchParams(existingQuery);
 
     if (queryParams) {
       for (const [key, value] of Object.entries(queryParams)) {
         if (value !== undefined) {
-          parsedUrl.searchParams.set(key, String(value));
+          searchParams.set(key, String(value));
         }
       }
     }
 
-    return parsedUrl.toString();
+    const query = searchParams.toString();
+    return `${appendPath(basePath)}${query ? `?${query}` : ''}`;
   }
 
-  private assertSafeFieldName(fieldName: string, fieldContext: string): string {
-    // Reject names that could turn into prototype pollution or nested field injection.
+  private assertSafeWriteFieldName(fieldName: string, fieldContext: string): string {
+    // Reject names that could turn into prototype pollution or nested field injection on write.
     if (!fieldName) {
       throw new BadRequestException(`${fieldContext} must not be empty`);
     }
@@ -227,8 +255,7 @@ export class ElasticService {
     const url = this.buildElasticUrl(this.options.url, [collection, '_search']);
 
     const profiler = new PerformanceProfiler();
-    // The final stored field name is still validated after prefixing to avoid unsafe mapping keys.
-    const fullAttribute = this.assertSafeFieldName(customValuePrefix + '_' + this.assertSafeFieldName(attribute, 'Attribute'), 'Custom value field');
+    const fullAttribute = `${customValuePrefix}_${attribute}`;
 
     const payload = {
       query: {
@@ -267,7 +294,7 @@ export class ElasticService {
     // Use a null-prototype object so malicious keys cannot inherit Object.prototype behavior.
     const doc: Record<string, T> = Object.create(null) as Record<string, T>;
     for (const [key, value] of Object.entries(dict)) {
-      const fullAttribute = this.assertSafeFieldName(customValuePrefix + '_' + this.assertSafeFieldName(key, 'Custom value key'), 'Custom value field');
+      const fullAttribute = `${customValuePrefix}_${this.assertSafeWriteFieldName(key, 'Custom value key')}`;
       doc[fullAttribute] = value;
     }
 
@@ -289,7 +316,7 @@ export class ElasticService {
 
     const profiler = new PerformanceProfiler();
     // The single-field update uses the same validation as the bulk update path.
-    const fullAttribute = this.assertSafeFieldName(customValuePrefix + '_' + this.assertSafeFieldName(attribute, 'Attribute'), 'Custom value field');
+    const fullAttribute = `${customValuePrefix}_${this.assertSafeWriteFieldName(attribute, 'Attribute')}`;
 
     const payload = {
       doc: Object.create(null) as Record<string, T>,

--- a/packages/elastic/src/elastic.service.ts
+++ b/packages/elastic/src/elastic.service.ts
@@ -14,8 +14,47 @@ export class ElasticService {
     private readonly metricsService: MetricsService,
   ) { }
 
+  private buildElasticUrl(baseUrl: string, pathSegments: string[], queryParams?: Record<string, string | number | boolean | undefined>): string {
+    // Build URLs through the URL API so path segments are encoded instead of concatenated raw.
+    const parsedUrl = new URL(baseUrl);
+
+    const basePath = parsedUrl.pathname.endsWith('/') ? parsedUrl.pathname.slice(0, -1) : parsedUrl.pathname;
+    const encodedPath = pathSegments.map(segment => encodeURIComponent(segment)).join('/');
+
+    parsedUrl.pathname = [basePath, encodedPath].filter(Boolean).join('/');
+    parsedUrl.search = '';
+    parsedUrl.hash = '';
+
+    if (queryParams) {
+      for (const [key, value] of Object.entries(queryParams)) {
+        if (value !== undefined) {
+          parsedUrl.searchParams.set(key, String(value));
+        }
+      }
+    }
+
+    return parsedUrl.toString();
+  }
+
+  private assertSafeFieldName(fieldName: string, fieldContext: string): string {
+    // Reject names that could turn into prototype pollution or nested field injection.
+    if (!fieldName) {
+      throw new BadRequestException(`${fieldContext} must not be empty`);
+    }
+
+    if (fieldName === '__proto__' || fieldName === 'prototype' || fieldName === 'constructor') {
+      throw new BadRequestException(`${fieldContext} contains an unsafe field name`);
+    }
+
+    if (fieldName.includes('.')) {
+      throw new BadRequestException(`${fieldContext} must not contain dots`);
+    }
+
+    return fieldName;
+  }
+
   async getCount(collection: string, elasticQuery: ElasticQuery | undefined = undefined) {
-    const url = `${this.options.url}/${collection}/_count`;
+    const url = this.buildElasticUrl(this.options.url, [collection, '_count']);
 
     const profiler = new PerformanceProfiler();
 
@@ -31,11 +70,18 @@ export class ElasticService {
   }
 
   async getItem(collection: string, key: string, identifier: string) {
-    const url = `${this.options.url}/${collection}/_search?q=_id:${identifier}`;
+    const url = this.buildElasticUrl(this.options.url, [collection, '_search']);
 
     const profiler = new PerformanceProfiler();
 
-    const result = await this.get(url);
+    // Keep the lookup in the request body so identifier content cannot break the query string.
+    const result = await this.post(url, {
+      query: {
+        term: {
+          _id: identifier,
+        },
+      },
+    });
 
     profiler.stop();
     this.metricsService.setElasticDuration(collection, ElasticMetricType.item, profiler.duration);
@@ -112,7 +158,7 @@ export class ElasticService {
   }
 
   async getList(collection: string, key: string, elasticQuery: ElasticQuery, overrideUrl?: string, searchAfter?: string | any[]): Promise<any[]> {
-    const url = `${overrideUrl ?? this.options.url}/${collection}/_search`;
+    const url = this.buildElasticUrl(overrideUrl ?? this.options.url, [collection, '_search']);
 
     const profiler = new PerformanceProfiler();
 
@@ -128,7 +174,7 @@ export class ElasticService {
   async getScrollableList(collection: string, key: string, elasticQuery: ElasticQuery, action: (items: any[]) => Promise<void>, options?: { scrollTimeout?: string, delayBetweenScrolls?: number }): Promise<void> {
     const scrollTimeout = options?.scrollTimeout ?? '1m';
 
-    const url = `${this.options.url}/${collection}/_search?scroll=${scrollTimeout}`;
+    const url = this.buildElasticUrl(this.options.url, [collection, '_search'], { scroll: scrollTimeout });
 
     const profiler = new PerformanceProfiler();
 
@@ -146,7 +192,7 @@ export class ElasticService {
       while (true) {
         const scrollProfiler = new PerformanceProfiler();
 
-        const scrollResult = await this.post(`${this.options.url}/_search/scroll`, {
+        const scrollResult = await this.post(this.buildElasticUrl(this.options.url, ['_search', 'scroll']), {
           scroll: scrollTimeout,
           scroll_id: scrollId,
         });
@@ -166,7 +212,7 @@ export class ElasticService {
         }
       }
     } finally {
-      await this.delete(`${this.options.url}/_search/scroll`, {
+      await this.delete(this.buildElasticUrl(this.options.url, ['_search', 'scroll']), {
         scroll_id: scrollId,
       });
     }
@@ -178,12 +224,18 @@ export class ElasticService {
       throw new Error('Custom value prefix not defined in the elastic service options');
     }
 
-    const url = `${this.options.url}/${collection}/_search?q=_id:${encodeURIComponent(identifier)}`;
+    const url = this.buildElasticUrl(this.options.url, [collection, '_search']);
 
     const profiler = new PerformanceProfiler();
-    const fullAttribute = customValuePrefix + '_' + attribute;
+    // The final stored field name is still validated after prefixing to avoid unsafe mapping keys.
+    const fullAttribute = this.assertSafeFieldName(customValuePrefix + '_' + this.assertSafeFieldName(attribute, 'Attribute'), 'Custom value field');
 
     const payload = {
+      query: {
+        term: {
+          _id: identifier,
+        },
+      },
       _source: fullAttribute,
     };
 
@@ -208,13 +260,15 @@ export class ElasticService {
       throw new Error('Custom value prefix not defined in the elastic service options');
     }
 
-    const url = `${this.options.url}/${collection}/_update/${identifier}`;
+    const url = this.buildElasticUrl(this.options.url, [collection, '_update', identifier]);
 
     const profiler = new PerformanceProfiler();
 
-    const doc: Record<string, T> = {};
+    // Use a null-prototype object so malicious keys cannot inherit Object.prototype behavior.
+    const doc: Record<string, T> = Object.create(null) as Record<string, T>;
     for (const [key, value] of Object.entries(dict)) {
-      doc[customValuePrefix + '_' + key] = value;
+      const fullAttribute = this.assertSafeFieldName(customValuePrefix + '_' + this.assertSafeFieldName(key, 'Custom value key'), 'Custom value field');
+      doc[fullAttribute] = value;
     }
 
     const payload = { doc };
@@ -231,16 +285,17 @@ export class ElasticService {
       throw new Error('Custom value prefix not defined in the elastic service options');
     }
 
-    const url = `${this.options.url}/${collection}/_update/${identifier}`;
+    const url = this.buildElasticUrl(this.options.url, [collection, '_update', identifier]);
 
     const profiler = new PerformanceProfiler();
-    const fullAttribute = customValuePrefix + '_' + attribute;
+    // The single-field update uses the same validation as the bulk update path.
+    const fullAttribute = this.assertSafeFieldName(customValuePrefix + '_' + this.assertSafeFieldName(attribute, 'Attribute'), 'Custom value field');
 
     const payload = {
-      doc: {
-        [fullAttribute]: value,
-      },
+      doc: Object.create(null) as Record<string, T>,
     };
+
+    payload.doc[fullAttribute] = value;
 
     await this.post(url, payload);
 

--- a/packages/elastic/test/elastic.service.spec.ts
+++ b/packages/elastic/test/elastic.service.spec.ts
@@ -78,4 +78,16 @@ describe('ElasticService security hardening', () => {
     await expect(service.setCustomValue('index', 'id', '__proto__', 'value')).rejects.toBeInstanceOf(BadRequestException);
     await expect(service.setCustomValue('index', 'id', 'nested.field', 'value')).rejects.toBeInstanceOf(BadRequestException);
   });
+
+  it('rejects a dotted custom field that would previously have reached Elasticsearch for a write operation', async () => {
+    const service = createService();
+
+    await expect(
+      service.setCustomValues('index', 'id', {
+        'profile.isAdmin': true as any,
+      }),
+    ).rejects.toBeInstanceOf(BadRequestException);
+
+    expect(apiService.post).not.toHaveBeenCalled();
+  });
 });

--- a/packages/elastic/test/elastic.service.spec.ts
+++ b/packages/elastic/test/elastic.service.spec.ts
@@ -47,6 +47,48 @@ describe('ElasticService security hardening', () => {
     expect(Object.getPrototypeOf(apiService.post.mock.calls[0][1].doc)).toBeNull();
   });
 
+  it('preserves comma-separated multi-index collections in the built URL', async () => {
+    apiService.post.mockResolvedValueOnce({
+      data: {
+        count: 0,
+      },
+    });
+
+    const service = createService();
+
+    await service.getCount('idx-a,idx-b');
+
+    expect(apiService.post).toHaveBeenCalledWith(
+      'https://elastic.example.com/base/idx-a,idx-b/_count',
+      undefined,
+    );
+  });
+
+  it('supports scheme-less configured base URLs without dropping request paths', async () => {
+    apiService.post.mockResolvedValueOnce({
+      data: {
+        hits: {
+          hits: [],
+        },
+      },
+    });
+
+    const service = createService('localhost:9200');
+
+    await service.getItem('index', 'id', '123');
+
+    expect(apiService.post).toHaveBeenCalledWith(
+      'localhost:9200/index/_search',
+      {
+        query: {
+          term: {
+            _id: '123',
+          },
+        },
+      },
+    );
+  });
+
   it('uses a search body instead of a query string for item lookups', async () => {
     apiService.post.mockResolvedValueOnce({
       data: {
@@ -89,5 +131,64 @@ describe('ElasticService security hardening', () => {
     ).rejects.toBeInstanceOf(BadRequestException);
 
     expect(apiService.post).not.toHaveBeenCalled();
+  });
+
+  it('allows dotted custom fields on reads so existing stored data stays reachable', async () => {
+    apiService.post.mockResolvedValueOnce({
+      data: {
+        hits: {
+          hits: [
+            {
+              _source: {
+                'meta_profile.role': 'admin',
+              },
+            },
+          ],
+        },
+      },
+    });
+
+    const service = createService();
+
+    await expect(service.getCustomValue('index', 'id', 'profile.role')).resolves.toBe('admin');
+
+    expect(apiService.post).toHaveBeenCalledWith(
+      'https://elastic.example.com/base/index/_search',
+      {
+        query: {
+          term: {
+            _id: 'id',
+          },
+        },
+        _source: 'meta_profile.role',
+      },
+    );
+  });
+
+  it('builds bulk update payloads with a null prototype and prefixed keys', async () => {
+    apiService.post.mockResolvedValueOnce({
+      data: {
+        result: 'updated',
+      },
+    });
+
+    const service = createService();
+
+    await service.setCustomValues('index', 'id', {
+      status: 'ok',
+      version: 2,
+    });
+
+    expect(apiService.post).toHaveBeenCalledWith(
+      'https://elastic.example.com/base/index/_update/id',
+      {
+        doc: expect.any(Object),
+      },
+    );
+
+    const doc = apiService.post.mock.calls[0][1].doc;
+    expect(doc.meta_status).toBe('ok');
+    expect(doc.meta_version).toBe(2);
+    expect(Object.getPrototypeOf(doc)).toBeNull();
   });
 });

--- a/packages/elastic/test/elastic.service.spec.ts
+++ b/packages/elastic/test/elastic.service.spec.ts
@@ -1,0 +1,81 @@
+import { BadRequestException } from "@nestjs/common";
+import { ElasticService } from "../src/elastic.service";
+import { ElasticModuleOptions } from "../src/entities/elastic.module.options";
+
+describe('ElasticService security hardening', () => {
+  const apiService = {
+    get: jest.fn(),
+    post: jest.fn(),
+    delete: jest.fn(),
+  };
+
+  const metricsService = {
+    setElasticDuration: jest.fn(),
+  };
+
+  const createService = (url = 'https://elastic.example.com/base') => new ElasticService(
+    new ElasticModuleOptions({ url, customValuePrefix: 'meta' }),
+    apiService as any,
+    metricsService as any,
+  );
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('encodes collection and identifier path segments before posting', async () => {
+    apiService.post.mockResolvedValueOnce({
+      data: {
+        hits: {
+          hits: [],
+        },
+      },
+    });
+
+    const service = createService();
+
+    await service.setCustomValue('index/name', 'id/with?special#chars', 'status', 'ok');
+
+    expect(apiService.post).toHaveBeenCalledWith(
+      'https://elastic.example.com/base/index%2Fname/_update/id%2Fwith%3Fspecial%23chars',
+      {
+        doc: expect.any(Object),
+      },
+    );
+
+    expect(apiService.post.mock.calls[0][1].doc.meta_status).toBe('ok');
+    expect(Object.getPrototypeOf(apiService.post.mock.calls[0][1].doc)).toBeNull();
+  });
+
+  it('uses a search body instead of a query string for item lookups', async () => {
+    apiService.post.mockResolvedValueOnce({
+      data: {
+        hits: {
+          hits: [],
+        },
+      },
+    });
+
+    const service = createService();
+
+    await service.getItem('index/name', 'id', 'abc/def');
+
+    expect(apiService.post).toHaveBeenCalledWith(
+      'https://elastic.example.com/base/index%2Fname/_search',
+      {
+        query: {
+          term: {
+            _id: 'abc/def',
+          },
+        },
+      },
+    );
+  });
+
+  it('rejects unsafe update field names that could pollute objects or create nested mappings', async () => {
+    const service = createService();
+
+    await expect(service.setCustomValue('index', 'id', '__proto__', 'value')).rejects.toBeInstanceOf(BadRequestException);
+    await expect(service.setCustomValue('index', 'id', 'nested.field', 'value')).rejects.toBeInstanceOf(BadRequestException);
+  });
+});

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-nestjs-http",
-  "version": "7.2.0",
+  "version": "7.2.1",
   "description": "Multiversx SDK Nestjs http package",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/monitoring/package.json
+++ b/packages/monitoring/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-nestjs-monitoring",
-  "version": "7.2.0",
+  "version": "7.2.1",
   "description": "Multiversx SDK Nestjs monitoring package",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/rabbitmq/package.json
+++ b/packages/rabbitmq/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-nestjs-rabbitmq",
-  "version": "7.2.0",
+  "version": "7.2.1",
   "description": "Multiversx SDK Nestjs rabbitmq client package",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/packages/redis/package.json
+++ b/packages/redis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-nestjs-redis",
-  "version": "7.2.0",
+  "version": "7.2.1",
   "description": "Multiversx SDK Nestjs redis client package",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",


### PR DESCRIPTION
## Reasoning
- The elastic updater was writing data to Elasticsearch without validating token identifiers or sanitizing nested payload keys.
- That could allow unsafe object shapes to reach the update layer, including prototype-pollution style inputs or malformed identifiers.

## Proposed Changes
- Added strict identifier validation before any elastic update is performed.
- Added recursive sanitization for assets, media, and metadata payloads, with rejection of unsafe keys like `__proto__`, `constructor`, and `prototype`.
- Added guards for undefined payloads and improved error logging around skipped updates.

## How to test
- Run `npx lerna run build`.
- Run `npx jest src/test/unit/crons/elastic.updater.service.spec.ts --runInBand`.
- Verify the new unit tests pass and unsafe identifiers/payload keys are rejected.